### PR TITLE
Update fa_tts.py

### DIFF
--- a/mycroft/tts/fa_tts.py
+++ b/mycroft/tts/fa_tts.py
@@ -50,7 +50,7 @@ class FATTSValidator(TTSValidator):
 
     def validate_connection(self):
         try:
-            resp = requests.get(self.tts.url + "/info/version", verify=False)
+            resp = requests.get(self.tts.url + "/info/version", verify=True)
             content = resp.json()
             if content.get('product', '').find('FA-TTS') < 0:
                 raise Exception('Invalid FA-TTS server.')


### PR DESCRIPTION
Requests call with verify=False disabling SSL certificate checks, security issue.
missing certificate validation
Example:
requests.get('https://example.com', verify=True)
   requests.get('https://example.com', verify=False)
   requests.post('https://example.com', verify=True)

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
